### PR TITLE
Fix regression tests broken by addition of license header comments

### DIFF
--- a/testdata/decoration.nopyi.py
+++ b/testdata/decoration.nopyi.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 def decoration(func):
     # type: (Any) -> Any
     return func

--- a/testdata/defaults.nopyi.py
+++ b/testdata/defaults.nopyi.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 def f1(x="foo"):
     # type: (str) -> None
     pass

--- a/testdata/heuristics.comment.py
+++ b/testdata/heuristics.comment.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 # If not annotate_pep484, info in pyi files is augmented with heuristics to decide if un-annotated
 # arguments are "Any" or "" (like "self")
 

--- a/testdata/heuristics.nopyi.py
+++ b/testdata/heuristics.nopyi.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 # If not annotate_pep484, info in pyi files is augmented with heuristics to decide if un-annotated
 # arguments are "Any" or "" (like "self")
 

--- a/testdata/imports_notouch.nopyi.py
+++ b/testdata/imports_notouch.nopyi.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 def func_without_annotation(x):
     # type: (Any) -> None
     pass

--- a/testdata/member_var.nopyi.py
+++ b/testdata/member_var.nopyi.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 # pytype generates member variable annotations as comments, check that fix_annotate ignores them
 # properly
 

--- a/testdata/mismatch.nopyi.py
+++ b/testdata/mismatch.nopyi.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 def f1(*a):
     # type: (*Any) -> None
     pass

--- a/testdata/packed_tuple.nopyi.py
+++ b/testdata/packed_tuple.nopyi.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 # tuple unpacking
 def f1((a, b)):
     # type: (Any) -> None

--- a/testdata/partial.comment.py
+++ b/testdata/partial.comment.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 def f1(a, b : int):
     pass
 

--- a/testdata/partial.nopyi.py
+++ b/testdata/partial.nopyi.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 def f1(a, b : int):
     pass
 

--- a/testdata/pyi_variations.comment.py
+++ b/testdata/pyi_variations.comment.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 def f1(x):
     # type: (e1) -> r1
     pass

--- a/testdata/pyi_variations.nopyi.py
+++ b/testdata/pyi_variations.nopyi.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 def f1(x):
     # type: (Any) -> None
     pass

--- a/testdata/redefine.comment.py
+++ b/testdata/redefine.comment.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 def f1(x):
     # type: (Any) -> Union[int, str]
     return 1

--- a/testdata/redefine.nopyi.py
+++ b/testdata/redefine.nopyi.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 def f1(x):
     # type: (Any) -> Any
     return 1

--- a/testdata/retval_heuristics.comment.py
+++ b/testdata/retval_heuristics.comment.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 # With heuristics, have to pick between returning None or Any. If generating comment annotations,
 # heuristics matter even if we have a pyi
 

--- a/testdata/retval_heuristics.nopyi.py
+++ b/testdata/retval_heuristics.nopyi.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 # With heuristics, have to pick between returning None or Any. If generating comment annotations,
 # heuristics matter even if we have a pyi
 

--- a/testdata/scope.nopyi.py
+++ b/testdata/scope.nopyi.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 class C(object):
     def f(self, x):
         # type: (Any) -> None

--- a/testdata/simple.comment.py
+++ b/testdata/simple.comment.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 def f1(a, b):
     # type: (Any, Any) -> r1
     """Doc"""

--- a/testdata/simple.nopyi.py
+++ b/testdata/simple.nopyi.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 def f1(a, b):
     # type: (Any, Any) -> Any
     """Doc"""

--- a/testdata/simple_defaults.nopyi.py
+++ b/testdata/simple_defaults.nopyi.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 def f1(x=12):
     # type: (int) -> None
     pass

--- a/testdata/stars.nopyi.py
+++ b/testdata/stars.nopyi.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 def f1(*a):
     # type: (*Any) -> None
     pass

--- a/testdata/trailing_comma.nopyi.py
+++ b/testdata/trailing_comma.nopyi.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 # Test trailing comma after last arg
 
 def h1(a,):

--- a/testdata/typevar.comment.py
+++ b/testdata/typevar.comment.py
@@ -1,8 +1,8 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Dict
 from typing import TypeVar
 _KT = TypeVar('_KT')
 _VT = TypeVar('_VT')
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 class UserDict(object):
     def __init__(self, initialdata = None):
         # type: (Dict[_KT, _VT]) -> None

--- a/testdata/typevar.nopyi.py
+++ b/testdata/typevar.nopyi.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Any
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 class UserDict(object):
     def __init__(self, initialdata = None):
         # type: (Any) -> None

--- a/testdata/typevar.pep484.py
+++ b/testdata/typevar.pep484.py
@@ -1,8 +1,8 @@
-# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 from typing import Dict
 from typing import TypeVar
 _KT = TypeVar('_KT')
 _VT = TypeVar('_VT')
+# Copyright (c) 2016 Google Inc. (under http://www.apache.org/licenses/LICENSE-2.0)
 class UserDict(object):
     def __init__(self, initialdata: Dict[_KT, _VT] = None):
         pass


### PR DESCRIPTION
in these cases, would like the typing imports to be below the license header, so this change is just so the tests pass again.

this doesn't happen if the source .py has an import
